### PR TITLE
Bug fixes and simplified install

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This document provides a comprehensive overview of the updated ONT-cappable-seq 
 
 ## Installation
 
+**Note:** This snakemake pipeline is designed for Linux systems! Windows users are advised to install [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) before proceeding with the installation.
+
 1. Install Snakemake by following the [instructions provided here](https://snakemake.readthedocs.io/en/stable/getting_started/installation.html).
 
 2. Clone the ONT-cappable-seq2 repository to the desired location to obtain the Snakemake pipeline:
@@ -51,7 +53,7 @@ ONT-cappable-seq2/
 
 ```yaml
 Sample name: sampleID
-fasta file: input/genome_data/sampleID.fasta 
+fasta file: input/genome_data/sampleID.fasta
 enriched fastq: input/fastq_data/sampleID_enriched.fastq
 control fastq: input/fastq_data/sampleID_control.fastq
 ID: group
@@ -61,14 +63,14 @@ cluster width:
   TSS: 15
   TTS: 30
 
-minimum coverage: 
+minimum coverage:
   enriched:
     TSS: 25
     TTS: 25
   control:
     TSS: 2
     TTS: 2
-    
+
 peak alignment error: 2
 TSS Threshold: 1.5
 TTS threshold: 0.25

--- a/README.md
+++ b/README.md
@@ -1,7 +1,113 @@
 # ONT-cappable-seq2
 
-We describe here a general overview of the updated ONT-cappable-seq data analysis pipeline, which is now fully automated. For a more detailed overview of individual steps, see the old ONT-cappable-seq repository.
+This document provides a comprehensive overview of the updated ONT-cappable-seq data analysis pipeline, now fully automated. For detailed information on individual steps, please refer to the [old ONT-cappable-seq repository](https://github.com/LoGT-KULeuven/ONT-cappable-seq).
 
-### **I. Data navigation**
+## Installation
 
-### **II. Setting up the configuration file**
+1. Install Snakemake by following the [instructions provided here](https://snakemake.readthedocs.io/en/stable/getting_started/installation.html).
+
+2. Clone the ONT-cappable-seq2 repository to the desired location to obtain the Snakemake pipeline:
+
+```bash
+git clone https://github.com/LoGT-KULeuven/ONT-cappable-seq2.git
+```
+
+## Usage
+
+### I. Data Navigation
+
+Obtain high-quality FASTA files for the reference genomes of the organisms you are studying and store them in the `input/genome_data` directory. For better organization, it is advisable to rename the FASTA files using the respective IDs of the phage or host, referred to as `sampleID`. Additionally, download the FLuc Control Plasmid sequence used for in vitro transcription of the RNA control spike-in from the manufacturer's website. Save this sequence in an appropriate location.
+
+```
+ONT-cappable-seq2/
+…
+├── input/
+|     └── genome_data/
+|          ├── phageID.fasta
+|          ├── hostID.fasta
+|          └── in-vitro-RNA.fasta
+```
+
+
+Place the raw sequencing files in the `input/fastq_data` directory and rename them to incorporate information about `sampleID` and treatment (enriched or control sample). Ensure that each individual sample has a single decompressed .fastq file with an adequate number of reads and a suitable mean read length (> 200 bp). This naming convention and file organization will contribute to the clarity and efficiency of the analysis.
+
+```
+ONT-cappable-seq2/
+…
+├── input/
+|     ├─ fastq_data/
+|        ├── sampleID_enriched.fastq
+|        └── sampleID_control.fastq
+|     └── genome_data/
+|        ├── phageID.fasta
+|        ├── hostID.fasta
+|        └── in-vitro-RNA.fasta
+```
+### II. Setting up the Configuration File
+
+1. Navigate to the `config` directory within the ONT-cappable-seq project folder.
+
+2. Open the `config.yaml` file. This file contains paths to your input files and various parameters used for annotating transcriptional boundaries. A general example of the config.yaml file is displayed below:
+
+```yaml
+Sample name: sampleID
+fasta file: input/genome_data/sampleID.fasta 
+enriched fastq: input/fastq_data/sampleID_enriched.fastq
+control fastq: input/fastq_data/sampleID_control.fastq
+ID: group
+termseq alpha: 0.001
+
+cluster width:
+  TSS: 15
+  TTS: 30
+
+minimum coverage: 
+  enriched:
+    TSS: 25
+    TTS: 25
+  control:
+    TSS: 2
+    TTS: 2
+    
+peak alignment error: 2
+TSS Threshold: 1.5
+TTS threshold: 0.25
+
+TSS sequence extraction:
+  upstream: 40
+  downstream: 0
+
+TTS sequence extraction:
+  upstream: 30
+  downstream: 30
+```
+
+- **Sample name**: Contains the name of your organism of interest (e.g., sampleID, LUZ19).
+- **Fasta file**: Path to your reference genome (e.g., `input/genome_data/sampleID.fasta`, `input/genome_data/LUZ19.fasta`).
+- **Enriched fastq**: Path to the raw sequencing file of the enriched sample (e.g., `input/fastq_data/sampleID_enriched.fastq`, `input/fastq_data/LUZ19_enriched.fastq`).
+- **Control fastq**: Path to the raw sequencing file of the control sample (e.g., `input/fastq_data/sampleID_control.fastq`, `input/fastq_data/LUZ19_control.fastq`).
+- **ID**: Additional identifier for sample classification (e.g., timepoint, condition, replicate).
+- **Termseq alpha**: Peak calling threshold for the termseq-peak algorithm.
+- **Cluster width**: Distance within which peak positions are clustered.
+- **Minimum coverage**: Minimum number of reads required for a candidate TSS/TTS position.
+- **Peak alignment error**: Positional difference allowed between peak positions in enriched and control datasets.
+- **TSS/TTS threshold**: Enrichment ratio and read reduction thresholds for TSS and TTS annotation.
+- **TSS/TTS sequence extraction**: Upstream and downstream nucleotides relative to TSS and TTS for DNA sequence extraction.
+
+
+
+### III. Running the Pipeline
+
+Before executing the Snakemake pipeline, perform a dry-run to ensure the workflow is correctly defined:
+
+```bash
+cd ONT-cappable-seq2
+snakemake --dry-run
+```
+
+To run the Snakemake pipeline, use the following commands:
+```bash
+cd ONT-cappable-seq2
+snakemake --use-conda --cores 8
+```
+During the initial run, the pipeline will install all necessary Conda packages, which may take some time. Subsequent runs will reuse this Conda environment.

--- a/workflow/envs/env_transcription_boundaries.yaml
+++ b/workflow/envs/env_transcription_boundaries.yaml
@@ -13,6 +13,7 @@ dependencies:
   - idr
   - deeptools
   - samtools
+  - ncurses
   - bedtools
   - r-base
   - r-dplyr

--- a/workflow/envs/env_transcription_boundaries.yaml
+++ b/workflow/envs/env_transcription_boundaries.yaml
@@ -1,7 +1,20 @@
 channels:
+  - defaults
   - conda-forge
   - bioconda
 dependencies:
-- samtools
-- bedtools
-- r-base
+  - python
+  - pip
+  - setuptools
+  - scipy
+  - pandas
+  - numpy<=1.19.5
+  - pybedtools
+  - idr
+  - deeptools
+  - samtools
+  - bedtools
+  - r-base
+  - r-dplyr
+  - pip:
+    - "--editable=git+https://github.com/NICHD-BSPC/termseq-peaks@master#egg=termseq-peaks"

--- a/workflow/rules/annotateTTS.smk
+++ b/workflow/rules/annotateTTS.smk
@@ -108,9 +108,23 @@ rule combinePosAndNegBedFilesTTS:
         """
         cat {input} > {output}
         """
+
+rule correctNegativeValuesTTS:
+    input:
+        'results/transcript_boundaries/TTS_{sample}/TTS_{sample}_{ident}/TTS_{sample}_{ident}.bed'
+    output:
+        'results/transcript_boundaries/TTS_{sample}/TTS_{sample}_{ident}/TTS_{sample}_{ident}_corrected.bed'
+    run:
+        with open(input[0], 'r') as infile, open(output[0], 'w') as outfile:
+            for line in infile:
+                parts = line.split()
+                if int(parts[1]) < 0:
+                    parts[1] = '0'
+                outfile.write('\t'.join(parts) + '\n')
+
 rule extractSequencesTTS:
     input: 
-        'results/transcript_boundaries/TTS_{sample}/TTS_{sample}_{ident}/TTS_{sample}_{ident}.bed'
+        'results/transcript_boundaries/TTS_{sample}/TTS_{sample}_{ident}/TTS_{sample}_{ident}_corrected.bed'
     output:
         'results/transcript_boundaries/TTS_{sample}/TTS_{sample}_{ident}/TTS_seq_{sample}_{ident}.fa.out'
     params:

--- a/workflow/rules/determineTranscriptionBoundries.smk
+++ b/workflow/rules/determineTranscriptionBoundries.smk
@@ -46,14 +46,16 @@ rule combineCovAndPeaks:
         """
 # Adds total number of reads to the peaks coverage information.
 rule addTotalReadsToCounts:
-    input: '{sample}_peak_calling/{prefix}.{num}end.{sign}.peaks.oracle.narrowPeak.counts', 'results/alignments/BAM_files_{sample}/{prefix}.sorted.bam'
+    input: 
+        counts:'{sample}_peak_calling/{prefix}.{num}end.{sign}.peaks.oracle.narrowPeak.counts', 
+        bam='results/alignments/BAM_files_{sample}/{prefix}.sorted.bam'
     output: temp('{sample}_peak_calling/{prefix}.{num}end.{sign}.peaks.oracle.narrowPeak.counts.withTR')
     conda:
         "../envs/env_transcription_boundaries.yaml"
     shell:
         """
-        total_mapped=$(samtools view -c -F4 {input[1]})
-        awk "{{print \$0, $total_mapped}}" {input[0]} > {output}
+        total_mapped=$(samtools view -c -F4 {input.bam})
+        awk -v total_mapped=$total_mapped '{{print $0, total_mapped}}' {input.counts} > {output}
         """
 # uses custom R script to cluster peaks based on peaks coverage information + total number of reads.
 rule clusterReads:

--- a/workflow/rules/determineTranscriptionBoundries.smk
+++ b/workflow/rules/determineTranscriptionBoundries.smk
@@ -24,6 +24,8 @@ rule termseqPeakCalling:
     params:
         alpha=config["termseq alpha"],
         symb=lambda x: signToSymbol[x.sign]
+    conda:
+        "../envs/env_transcription_boundaries.yaml"
     shell:
         """
         termseq_peaks {input} {input} --peaks {output[0]} --strand {params.symb} -t {params.alpha} --oracle-output {output[1]}

--- a/workflow/rules/determineTranscriptionBoundries.smk
+++ b/workflow/rules/determineTranscriptionBoundries.smk
@@ -47,7 +47,7 @@ rule combineCovAndPeaks:
 # Adds total number of reads to the peaks coverage information.
 rule addTotalReadsToCounts:
     input: 
-        counts:'{sample}_peak_calling/{prefix}.{num}end.{sign}.peaks.oracle.narrowPeak.counts', 
+        counts='{sample}_peak_calling/{prefix}.{num}end.{sign}.peaks.oracle.narrowPeak.counts', 
         bam='results/alignments/BAM_files_{sample}/{prefix}.sorted.bam'
     output: temp('{sample}_peak_calling/{prefix}.{num}end.{sign}.peaks.oracle.narrowPeak.counts.withTR')
     conda:

--- a/workflow/rules/determineTranscriptionBoundries.smk
+++ b/workflow/rules/determineTranscriptionBoundries.smk
@@ -53,7 +53,7 @@ rule addTotalReadsToCounts:
     conda:
         "../envs/env_transcription_boundaries.yaml"
     shell:
-        """
+        r"""
         total_mapped=$(samtools view -c -F4 {input.bam})
         awk -v total_mapped=$total_mapped '{{print $0, total_mapped}}' {input.counts} > {output}
         """


### PR DESCRIPTION
r-dplyr and termseq-peaks now automatically installed when running the snakemake pipeline for the first time.
README file updated for easy reference.

Bugfixes:
- Rule addTotalReadsToCounts: total_mapped was not always correctly added to narrowPeak.counts, awk division by zero attempt solved, and SyntaxWarning on WSL solved
- Added rule correctNegativeValuesTTS to set negative starting positions to zero in bed file.